### PR TITLE
Remove main thread check from space_get_direct_state

### DIFF
--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -265,9 +265,7 @@ public:
 		return physics_server_3d->body_test_motion(p_body, p_parameters, r_result);
 	}
 
-	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectBodyState3D *body_get_direct_state(RID p_body) override {
-		ERR_FAIL_COND_V(!Thread::is_main_thread(), nullptr);
 		return physics_server_3d->body_get_direct_state(p_body);
 	}
 


### PR DESCRIPTION
This removes a check for if the function is called from the main thread. This check causes Raycast3D nodes to not function if they are running on a separate thread.

The physics servers already check if the state is available here so the check seems unnecessary.
https://github.com/redot-rex/rex-engine/blob/8d4894a5124d2cd0c1c995b7837078d57b01fe69/modules/jolt_physics/jolt_physics_server_3d.cpp#L233-L239

